### PR TITLE
Putting pipeline into error if apscli return anything else than 0 when saving and retrieving revision

### DIFF
--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -66,9 +66,12 @@ def retrieveRevisions(patchConfig) {
 	def lastRevision
 	def shOutputFileName = "shOutput"
 	
-	// TODO JHE: verify that we really wait on the script execution.
-	//           probably needs to handle exception
-	sh "/opt/apg-patch-cli/bin/apscli.sh -rr ${patchConfig.targetInd},${patchConfig.installationTarget},${patchConfig.revision} > ${shOutputFileName}"
+	def result = sh returnStatus: true, script: "/opt/apg-patch-cli/bin/apscli.sh -rr ${patchConfig.targetInd},${patchConfig.installationTarget},${patchConfig.revision} > ${shOutputFileName}"
+	
+	if(result != 0) {
+		// Put the pipeline in error
+		error "An error occured while saving revision file. Return status was ${result}"
+	}
 	
 	def lines = readFile(shOutputFileName).readLines()
 	lines.each {String line ->
@@ -86,9 +89,12 @@ def retrieveRevisions(patchConfig) {
 
 def saveRevisions(patchConfig) {
 	
-	// TODO JHE: verify that we really wait on the script execution.
-	//           probably needs to handle exception
-	sh "/opt/apg-patch-cli/bin/apscli.sh -sr ${patchConfig.targetInd},${patchConfig.installationTarget},${patchConfig.revision}"
+	def result = sh returnStatus: true, script: "/opt/apg-patch-cli/bin/apscli.sh -sr ${patchConfig.targetInd},${patchConfig.installationTarget},${patchConfig.revision}"
+
+	if(result != 0) {
+		// Put the pipeline in error
+		error "An error occured while saving revision file. Return status was ${result}"
+	}
 	
 }
 

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -68,7 +68,7 @@ def retrieveRevisions(patchConfig) {
 	
 	def result = sh returnStatus: true, script: "/opt/apg-patch-cli/bin/apscli.sh -rr ${patchConfig.targetInd},${patchConfig.installationTarget},${patchConfig.revision} > ${shOutputFileName} 2>pipelineErr.log"
 	
-	assert result == 0 : logErrorFromFileOnJenkinsConsole("pipelineErr.log")
+	assert result == 0 : println (new File("pipelineErr.log").text)
 	
 	def lines = readFile(shOutputFileName).readLines()
 	lines.each {String line ->
@@ -87,7 +87,7 @@ def retrieveRevisions(patchConfig) {
 def saveRevisions(patchConfig) {
 	
 	def result = sh returnStatus: true, script: "/opt/apg-patch-cli/bin/apscli.sh -sr ${patchConfig.targetInd},${patchConfig.installationTarget},${patchConfig.revision} 2>pipelineErr.log"
-	assert result == 0 : logErrorFromFileOnJenkinsConsole("pipelineErr.log")
+	assert result == 0 : println (new File("pipelineErr.log").text)
 }
 
 
@@ -320,17 +320,10 @@ def notify(target,toState,patchConfig) {
 		def notCmd = "/opt/apg-patch-cli/bin/apscli.sh -sta ${patchConfig.patchNummer},${targetToState},db 2>pipelineErr.log"
 		echo "Executeing ${notCmd}"
 		def result = sh returnStatus: true, script: notCmd
-		assert result == 0 : logErrorFromFileOnJenkinsConsole("pipelineErr.log")
+		assert result == 0 : println (new File("pipelineErr.log").text)
 		echo "Executeing ${notCmd} done"
 	}
 
-}
-
-def logErrorFromFileOnJenkinsConsole(def filePath) {
-	def lines = readFile(filePath).readLines()
-	lines.each {String line ->
-		 println line
-	}
 }
 
 def mapToState(target,toState) {

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -68,10 +68,7 @@ def retrieveRevisions(patchConfig) {
 	
 	def result = sh returnStatus: true, script: "/opt/apg-patch-cli/bin/apscli.sh -rr ${patchConfig.targetInd},${patchConfig.installationTarget},${patchConfig.revision} > ${shOutputFileName}"
 	
-	if(result != 0) {
-		// Put the pipeline in error
-		error "An error occured while saving revision file. Return status was ${result}"
-	}
+	assert result == 0 : "An error occured while saving revision file. Return status was ${result}"
 	
 	def lines = readFile(shOutputFileName).readLines()
 	lines.each {String line ->
@@ -90,12 +87,7 @@ def retrieveRevisions(patchConfig) {
 def saveRevisions(patchConfig) {
 	
 	def result = sh returnStatus: true, script: "/opt/apg-patch-cli/bin/apscli.sh -sr ${patchConfig.targetInd},${patchConfig.installationTarget},${patchConfig.revision}"
-
-	if(result != 0) {
-		// Put the pipeline in error
-		error "An error occured while saving revision file. Return status was ${result}"
-	}
-	
+	assert result == 0 : "An error occured while saving revision file. Return status was ${result}"
 }
 
 
@@ -328,6 +320,7 @@ def notify(target,toState,patchConfig) {
 		def notCmd = "/opt/apg-patch-cli/bin/apscli.sh -sta ${patchConfig.patchNummer},${targetToState},db"
 		echo "Executeing ${notCmd}"
 		sh "${notCmd}"
+		assert notCmd == 0 : "Error while notifying db for patch ${patchConfig.patchNummer} for state ${targetToState}"
 		echo "Executeing ${notCmd} done"
 	}
 

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -319,8 +319,8 @@ def notify(target,toState,patchConfig) {
 		def targetToState = mapToState(target,toState)
 		def notCmd = "/opt/apg-patch-cli/bin/apscli.sh -sta ${patchConfig.patchNummer},${targetToState},db"
 		echo "Executeing ${notCmd}"
-		sh "${notCmd}"
-		assert notCmd == 0 : "Error while notifying db for patch ${patchConfig.patchNummer} for state ${targetToState}"
+		def result = sh returnStatus: true, script: notCmd
+		assert result == 0 : "Error while notifying db for patch ${patchConfig.patchNummer} for state ${targetToState}"
 		echo "Executeing ${notCmd} done"
 	}
 


### PR DESCRIPTION
Nothing big, just to quickly look at the modification ... 
Basically, if apscli return anything else than 0 (when retrieveing and saving revision), we put the pipeline into error.