### PR TITLE
Che javamig 405 parallel builds

### DIFF
--- a/src/main/jenkins/server/testParallelBuilds.groovy
+++ b/src/main/jenkins/server/testParallelBuilds.groovy
@@ -20,5 +20,5 @@ println "TargetSystemsMap : ${targetSystemsMap} "
 	target = targetSystemsMap.get(envName)
 	assert target != null
 	patchfunctions.targetIndicator(patchConfig,target)
-	stage("${envName} (${target.targetName}) Build" ) { patchfunctions.patchBuilds(patchConfig)  }
+	stage("${envName} (${target.targetName}) Build" ) { patchfunctions.buildAndReleaseModulesConcurrent(patchConfig)  }
 }

--- a/src/main/jenkins/server/testParallelBuilds.groovy
+++ b/src/main/jenkins/server/testParallelBuilds.groovy
@@ -3,7 +3,7 @@ library 'patch-global-functions'
 library 'patch-deployment-functions'
 import groovy.json.JsonSlurperClassic
 
-def patchFile = new File("Some Test File")
+def patchFile = new File("/var/opt/apg-patch-service-server/db/Patch5739.json")
 def patchConfig = new JsonSlurperClassic().parseText(patchFile.text)
 echo patchConfig.toString()
 patchConfig.cvsroot = env.CVS_ROOT

--- a/src/main/jenkins/server/testParallelBuilds.groovy
+++ b/src/main/jenkins/server/testParallelBuilds.groovy
@@ -1,0 +1,24 @@
+#!groovy
+library 'patch-global-functions'
+library 'patch-deployment-functions'
+import groovy.json.JsonSlurperClassic
+
+def patchFile = new File("Some Test File")
+def patchConfig = new JsonSlurperClassic().parseText(patchFile.text)
+echo patchConfig.toString()
+patchConfig.cvsroot = env.CVS_ROOT
+patchConfig.jadasServiceArtifactName = "com.affichage.it21:it21-jadas-service-dist-gtar"
+patchConfig.dockerBuildExtention = "tar.gz"
+
+// Load Target System Mappings
+def targetSystemsMap = patchfunctions.loadTargetsMap()
+println "TargetSystemsMap : ${targetSystemsMap} "
+
+[
+	'Informatiktest',
+].each { envName ->
+	target = targetSystemsMap.get(envName)
+	assert target != null
+	patchfunctions.targetIndicator(patchConfig,target)
+	stage("${envName} (${target.targetName}) Build" ) { patchfunctions.patchBuilds(patchConfig)  }
+}

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -152,11 +152,7 @@ def buildAndReleaseModulesConcurrent(patchConfig) {
 }
 
 def buildAndReleaseModulesConcurrent(patchConfig,module) {
-	// We need to wrap what we return in a Groovy closure, or else it's invoked
-	// when this method is called, not when we pass it to parallel.
-	// To do this, you need to wrap the code below in { }, and either return
-	// that explicitly, or use { -> } syntax.
-	return {
+		return {
 		node {
 			buildAndReleaseModule(patchConfig,module)		
 		}

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -145,9 +145,10 @@ def buildAndReleaseModulesConcurrent(patchConfig) {
 	depLevels.reverse(true)
 	depLevels.each {
 		def artifactsToBuildParallel = listsByDepLevel[it]
-		def stepsForParallel = artifactsToBuildParallel.collectEntries {
+		def parallelBuilds = artifactsToBuildParallel.collectEntries {
 			buildAndReleaseModulesConcurrent(patchConfig,it)
 		}
+		parallel parallelBuilds
 	}
 }
 


### PR DESCRIPTION
Concurrent Build support & a test Pipeline to test the concurrent Build Process isolated.

Parallel Buildsupport has been added to [https://github.com/apgsga-it/jenkins-patch-scripts/blob/master/vars/patchfunctions.groovy](url) , look for buildAndReleaseModulesConcurrent. 
I have added it additionally to the sequential Build process, so we always have a fallback.

Currently the buildAndReleaseModulesConcurrent is only invoked from /jenkins-patch-scripts/src/main/jenkins/server/testParallelBuilds.groovy
