### PR TITLE
Delete all GUI folders but last 2.

### DIFF
--- a/vars/patchDeployment.groovy
+++ b/vars/patchDeployment.groovy
@@ -85,10 +85,19 @@ def installGUI(patchConfig,artifact,extension) {
 		renameExtractedGuiZip(extractedGuiPath,extractedFolderName)
 		copyGuiOpsResources(patchConfig,extractedGuiPath,extractedFolderName)
 		copyCitrixBatchFile(extractedGuiPath,extractedFolderName)
+		removeOldGuiFolder(extractedGuiPath)
 
 		// Unmount the share drive
 		powershell("net use ${extractedGuiPath} /delete")
 	}
+}
+
+def removeOldGuiFolder(extractedGuiPath) {
+	// JHE (15.08.2018) : We do this with Powershell as it contains build-in function which make it so easy to keep only the last X folders following a given pattern.
+	def guiFolderNamePrefix = "java_gui"
+	def nbFolderToKeep = "2"
+	powershell "Get-ChildItem ${extractedGuiPath} -Directory -Recurse -Include ${guiFolderNamePrefix}* | Sort-Object CreationTime -Descending | Select-Object -Skip ${nbFolderToKeep} | Remove-Item -Recurse -Force"
+	
 }
 
 def guiExtractedFolderName() {


### PR DESCRIPTION
When installing the GUI, we want to keep only the last 2 java_gui* folders.
A new powershell call has been introduced. I tested with a dummy pipeline, it worked well.
Why powershell ? Because it makes so easy to list the last X folder having a specific name.