### PR TITLE
install Jadas docker only under some conditions.

### DIFF
--- a/vars/patchDeployment.groovy
+++ b/vars/patchDeployment.groovy
@@ -6,11 +6,21 @@ def installDeploymentArtifacts(patchConfig) {
 		parallel 'ui-client-deployment': {
 			node {install(patchConfig,"client","it21gui-dist-zip","zip")}
 		}, 'ui-server-deployment': {
-			node {install(patchConfig,"docker",patchConfig.jadasServiceArtifactName,patchConfig.dockerBuildExtention) }
+			if(installDocker(patchConfig)) {
+				node {install(patchConfig,"docker",patchConfig.jadasServiceArtifactName,patchConfig.dockerBuildExtention) }
+			}
 		}, 'db-deployment': {
 			node {install(patchConfig,"db",patchfunctions.getCoPatchDbFolderName(patchConfig),"zip") }
 		}
 	}
+}
+
+def installDocker(patchConfig) {
+	def mavenArtifactList = patchConfig.mavenArtifacts
+	def dbObjectsLists = patchConfig.dbObjects
+	def installOnEmptyModules = patchConfig.installOnEmptyModules
+	
+	return !mavenArtifactList.isEmpty() || !dbObjectsLists.isEmpty() || installOnEmptyModules
 }
 
 def install(patchConfig, type, artifact,extension) {

--- a/vars/patchDeployment.groovy
+++ b/vars/patchDeployment.groovy
@@ -6,21 +6,13 @@ def installDeploymentArtifacts(patchConfig) {
 		parallel 'ui-client-deployment': {
 			node {install(patchConfig,"client","it21gui-dist-zip","zip")}
 		}, 'ui-server-deployment': {
-			if(installDocker(patchConfig)) {
+			if(patchConfig.installJadas) {
 				node {install(patchConfig,"docker",patchConfig.jadasServiceArtifactName,patchConfig.dockerBuildExtention) }
 			}
 		}, 'db-deployment': {
 			node {install(patchConfig,"db",patchfunctions.getCoPatchDbFolderName(patchConfig),"zip") }
 		}
 	}
-}
-
-def installDocker(patchConfig) {
-	def mavenArtifactList = patchConfig.mavenArtifacts
-	def dbObjectsLists = patchConfig.dbObjects
-	def installOnEmptyModules = patchConfig.installOnEmptyModules
-	
-	return !mavenArtifactList.isEmpty() || !dbObjectsLists.isEmpty() || installOnEmptyModules
 }
 
 def install(patchConfig, type, artifact,extension) {


### PR DESCRIPTION
Before starting the Docker (Jadas) installation, we check that either:

- We have at least one Java Artefact.
- We have at least one DB Module.
- We force an installation from an empty patch.

Do you see the pipeline modification differently?