### PR TITLE
After a Clone, if no PROD revision exists, use SNAPSHOT

### DIFF
--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -37,20 +37,30 @@ def targetIndicator(patchConfig, target) {
 
 def mavenVersionNumber(patchConfig,revision) {
 	def mavenVersion
-
+	
 	// Case where this is the first patch after having cloned the target
 	if(patchConfig.lastRevision == "CLONED") {
-		mavenVersion = patchConfig.baseVersionNumber + "." + patchConfig.revisionMnemoPart + "-P-" + getCurrentProdRevision()
-		patchConfig.lastRevision = patchConfig.revision
+		
+		if(getCurrentProdRevision() == null) {
+			mavenVersion = 	getMavenSnapshotVersion(patchConfig,revision)
+		}
+		else {
+			mavenVersion = patchConfig.baseVersionNumber + "." + patchConfig.revisionMnemoPart + "-P-" + getCurrentProdRevision()
+			patchConfig.lastRevision = patchConfig.revision
+		}
 	}
 	else {
 		if (revision.equals('SNAPSHOT')) {
-			mavenVersion = patchConfig.baseVersionNumber + "." + patchConfig.revisionMnemoPart + "-" + revision
+			mavenVersion = getMavenSnapshotVersion(patchConfig,revision)
 		} else {
 			mavenVersion = patchConfig.baseVersionNumber + "." + patchConfig.revisionMnemoPart + "-" + patchConfig.targetInd + '-' + revision
 		}
 	}
 	mavenVersion
+}
+
+def getMavenSnapshotVersion(def patchConfig,def revision) {
+	return patchConfig.baseVersionNumber + "." + patchConfig.revisionMnemoPart + "-" + revision
 }
 
 def getCurrentProdRevision() {


### PR DESCRIPTION
This address the last question of https://jira.apgsga.ch/browse/JAVA8MIG-432 ... where we need to work with SNAPSHOT after a Clone, if the PROD target has never been patched.