### PR TITLE
Testing restart

### DIFF
--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -11,6 +11,14 @@ def benchmark() {
 	benchmarkCallback
 }
 
+def failIf(parm) {
+	def testParameter = env.PATCH_SERVICE_TEST ? env.PATCH_SERVICE_TEST	: ""
+	if (testParameter.contentEquals(parm)) {
+		error("Forced error termination of pipeline, for testing purposes with parameter: ${parm}")
+		
+	}
+}
+
 def mavenLocalRepo(patchConfig) {
 	node {
 		dir('mavenLocalRepo') {
@@ -461,6 +469,7 @@ def notify(target,toState,patchConfig) {
 	if (toSkip(target,toState,patchConfig)) {
 		return
 	}
+	failIf("fail=" + mapToState(target,toState))
 	node {
 		echo "Notifying ${target} to ${toState}"
 		def targetToState = mapToState(target,toState)


### PR DESCRIPTION
To keep things simple i build a runtime condition depending on a Environment Variable to force the failure for a Pipeline execution.

I could have provided the same Parameter on the Rest API, but that would effect the all the endpoints and clients involved (cli, rest api patch service , jenkins pipeline) .  I decided against this for the moment. 

The drawback is that, also intended failures can be provoked, for example more then one testing at the same time.
