### PR TITLE
Redesign Redo 

### DIFF
--- a/src/main/jenkins/server/patchProdPipeline.groovy
+++ b/src/main/jenkins/server/patchProdPipeline.groovy
@@ -26,7 +26,7 @@ patchConfig.cvsroot = env.CVS_ROOT
 patchConfig.jadasServiceArtifactName = "com.affichage.it21:it21-jadas-service-dist-gtar"
 patchConfig.dockerBuildExtention = "tar.gz"
 patchConfig.patchFilePath = params.PARAMETER
-patchConfig.restart = params.RESTART.equals("TRUE")
+patchConfig.redo = params.RESTART.equals("TRUE")
 
 // Load Target System Mappings
 def targetSystemsMap = patchfunctions.loadTargetsMap()

--- a/src/main/jenkins/server/patchProdPipeline.groovy
+++ b/src/main/jenkins/server/patchProdPipeline.groovy
@@ -17,7 +17,7 @@ properties([
 	])
 ])
 
-// Parameter
+// Process Parameters
 // TODO  (che, 9.7) When JENKINS-27413 is resolved
 // Passing Patch File Path , because of JAVA8MIG-395 / JENKINS-27413
 def patchFile = new File(params.PARAMETER)
@@ -33,63 +33,33 @@ def targetSystemsMap = patchfunctions.loadTargetsMap()
 println "TargetSystemsMap : ${targetSystemsMap} "
 // Create a local Maven Repo for Pipeline
 patchfunctions.mavenLocalRepo(patchConfig)
-println patchConfig.mavenLocalRepo
-// Retrieve event. PrecessorsState , which will be skipped if in Restart Modues
+// Retrieve event. State, which will re - done
 patchfunctions.redoToState(patchConfig)
 
 // Mainline
-// While mit Start der Pipeline bereits getagt ist
 
+
+// Artefacts are tagged = ready to be buildt and deployed, we wait for Notification
 def target = targetSystemsMap.get('Entwicklung')
-def skip =!patchConfig.restart || !patchConfig.redoToState.equals(patchfunctions.mapToState(target,"Installationsbereit"))
-stage("${target.envName} (${target.targetName}) Installationsbereit Notification "  + (skip ? "(Skipped" : "")) {
-	if (!skip) {
-		patchfunctions.notify(target,"Installationsbereit", patchConfig)
-	}
-}
+patchfunctions.stage(target,"Installationsbreit",patchConfig,"Notification", patchfunctions.notify(patchConfig))
 
 ['Informatiktest', 'Produktion'].each { envName ->
 	target = targetSystemsMap.get(envName)
 	assert target != null
 	patchfunctions.targetIndicator(patchConfig,target)
-	skip = !patchConfig.restart || !patchConfig.redoToState.equals(patchfunctions.mapToState(target,"Installationsbereit"))
-	stage("Approve ${envName} (${target.targetName}) Build & Assembly ${patchConfig.skipText}") {
-		if (!skip) {
-			patchfunctions.approveBuild(patchConfig)
-		}
-	}
-	stage("${envName} (${target.targetName}) Build ${patchConfig.skipText}" ) {
-		if (!skip) {
-			patchfunctions.patchBuildsConcurrent(patchConfig)
-		}
-	}
-	stage("${envName} (${target.targetName}) Assembly ${patchConfig.skipText}" ) {
-		if (!skip) {
-			patchfunctions.assembleDeploymentArtefacts(patchConfig)
-		}
-	}
-	stage("${envName} (${target.targetName}) Installationsbereit Notification ${patchConfig.skipText}") {
-		if (!skip) {
-			patchfunctions.notify(target,"Installationsbereit", patchConfig)
-		}
-	}
-	stage("Approve ${envName} (${target.targetName}) Installation ${patchConfig.skipText}") {
-		if (!skip) {
-			patchfunctions.approveInstallation(patchConfig)
-		}
-	}
-	skip = !patchConfig.restart || !patchConfig.redoToState.equals(patchfunctions.mapToState(target,"Installation"))
-	stage("${envName} (${target.targetName}) Installation ${patchConfig.skipText}") {
-		if (!skip) {
-			patchDeployment.installDeploymentArtifacts(patchConfig)
-		}
-	}
-	stage("${envName} (${target.targetName}) Installation Notification ${patchConfig.skipText}") {
-		if(envName.equals("Produktion")) {
-			patchfunctions.mergeDbObjectOnHead(patchConfig, envName)
-		}
-		if (!skip) {
-			patchfunctions.notify(target,"Installation", patchConfig)
-		}
-	}
+
+	// Approve to make Patch "Installationsbereit" for target
+	patchfunctions.stage(target,"Installationsbereit",patchConfig,"Approve", patchfunctions.approveBuild(patchConfig))
+	patchfunctions.stage(target,"Installationsbereit",patchConfig,"Build", patchfunctions.patchBuildsConcurrent(patchConfig))
+	patchfunctions.stage(target,"Installationsbereit",patchConfig,"Assembly", patchfunctions.assembleDeploymentArtefacts(patchConfig))
+	patchfunctions.stage(target,"Installationsbereit",patchConfig,"Notification",  patchfunctions.notify(patchConfig))
+	
+	// Approve to to install Patch
+	
+	patchfunctions.stage(target,"Installation",patchConfig,"Approve", patchfunctions.approveInstallation(patchConfig))
+	patchfunctions.stage(target,"Installation",patchConfig,"Install", patchDeployment.installDeploymentArtifacts(patchConfig))
+	patchfunctions.stage(target,"Installation",patchConfig,"Notification",  patchfunctions.installationPostProcess(patchConfig))
+	patchfunctions.stage(target,"Installation",patchConfig,"Notification",  patchfunctions.notify(patchConfig))
+	
 }
+

--- a/src/test/groovy/closureTests.groovy
+++ b/src/test/groovy/closureTests.groovy
@@ -1,0 +1,16 @@
+def someFunc(someArg) {
+	println "someFunc doing something with ${someArg}"
+}
+
+def anotherFunc(someArg) {
+	println "anotherFunc doing something with ${someArg}"
+}
+
+def theFunc(test, someArg, callback) {
+	println "${test} with ${someArg} calling a fucntion"
+	callback(someArg)
+	callback()
+}
+
+def callBack = this.&anotherFunc
+theFunc("Some Test", "some arg", callBack)

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -11,12 +11,17 @@ def benchmark() {
 	benchmarkCallback
 }
 
-def stage(target,toState,patchConfig,Closure callBack) {
-	def skip =!patchConfig.restart || !patchConfig.redoToState.equals(patchfunctions.mapToState(target,toState))
-	stage("${target.envName} (${target.targetName}) Installationsbereit Notification "  + (skip ? "(Skipped" : "")) {
+def stage(target,toState,patchConfig,task, Closure callBack) {
+	patchConfig.targetToState = mapToState(target,toState)
+	def skip = patchConfig.redo && !patchConfig.redoToState.equals(patchConfig.targetToState)
+	def stageText = "${target.envName} (${target.targetName}) ${patchConfig.targetToState} ${task} "  + (skip ? "(Skipped)" : "")
+	stage(stageText) {
 		if (!skip) {
 			callBack(patchConfig)
-		}
+			if (patchConfig.restart && patchConfig.redoToState.equals(patchConfig.targetToState) && task.equals("Notification")) {
+				patchConfig.redo = false
+			}
+		}  
 	}
 }
 


### PR DESCRIPTION
I  changed the Redo Logic quite a bit. 

Now the redo logic is encapsulated in the new patchfunctions.stage function, which acutally abstracts the Stages. 

This is function is called by the mainline , with the corresponding "logic" passed as closure, 

The stages before are'nt "replayed" but skipped. The stage of the corresponding "Redo" State is redone and from then the Patch Pipeline is processed "normally".

@apgsga-jhe  FYI, i going ahead with mergeing and testing, i am terriblly curious, if this works ;-) 