### PR TITLE
JAVA8MIG-504 onDemand Pipeline installed on wrong target

### DIFF
--- a/src/main/jenkins/server/clone/reinstallPatchAfterClonePipeline.groovy
+++ b/src/main/jenkins/server/clone/reinstallPatchAfterClonePipeline.groovy
@@ -46,12 +46,12 @@ def reinstallPatch(def patch, def target) {
 	
 		def patchConfig = getPatchConfig(patch,target)
 		
-		def targetBean = [envName:target,targetName:patchConfig.installationTarget]
+		def targetBean = [envName:target,targetName:patchConfig.currentTarget]
 		patchfunctions.saveTarget(patchConfig,targetBean)
 		patchfunctions.mavenLocalRepo(patchConfig)
 		println patchConfig.mavenLocalRepo
 			
-		stage("Re-installing patch ${patch} on ${patchConfig.installationTarget}") {
+		stage("Re-installing patch ${patch} on ${patchConfig.currentTarget}") {
 			echo "Starting Build for patch ${patch}"
 			node {patchfunctions.patchBuildsConcurrent(patchConfig)}
 			echo "DONE - Build for patch ${patch}"
@@ -80,7 +80,7 @@ def getPatchConfig(def patch, def target) {
 	patchConfig.cvsroot = env.CVS_ROOT
 	patchConfig.jadasServiceArtifactName = "com.affichage.it21:it21-jadas-service-dist-gtar"
 	patchConfig.dockerBuildExtention = "tar.gz"
-	patchConfig.installationTarget = target
+	patchConfig.currentTarget = target
 	patchConfig.patchFilePath = "${env.PATCH_DB_FOLDER}${env.PATCH_FILE_PREFIX}${patch.toString()}.json"
 	echo "patchConfig for patch ${patch} : ${patchConfig}"
 	return patchConfig

--- a/vars/patchDeployment.groovy
+++ b/vars/patchDeployment.groovy
@@ -2,7 +2,7 @@
 library 'patch-global-functions'
 
 def installDeploymentArtifacts(patchConfig) {
-	lock("${patchConfig.serviceName}${patchConfig.installationTarget}Install") {
+	lock("${patchConfig.serviceName}${patchConfig.currentTarget}Install") {
 		parallel 'ui-client-deployment': {
 			if(patchConfig.installJadasAndGui) {
 				node {install(patchConfig,"client","it21gui-dist-zip","zip")}
@@ -31,7 +31,7 @@ def install(patchConfig, type, artifact,extension) {
 		}
 
 		def dropName = patchfunctions.jadasServiceDropName(patchConfig)
-		def dockerDeploy = "/opt/apgops/docker/deploy.sh jadas-service ${patchConfig.patchNummer}-${patchConfig.revision}-${patchConfig.runningNr} ${patchConfig.installationTarget}"
+		def dockerDeploy = "/opt/apgops/docker/deploy.sh jadas-service ${patchConfig.patchNummer}-${patchConfig.revision}-${patchConfig.runningNr} ${patchConfig.currentTarget}"
 		echo dockerDeploy
 		sh "${dockerDeploy}"
 	}
@@ -57,12 +57,12 @@ def installDbPatch(patchConfig,artifact,extension) {
 		
 		unzip zipFile: "download/${artifact}.${extension}"
 		
-		bat("cmd /c c:\\local\\software\\cm_winproc_root\\it21_extensions\\jenkins_pipeline_patch_install.bat ${patchDbFolderName} ${patchConfig.installationTarget}")
+		bat("cmd /c c:\\local\\software\\cm_winproc_root\\it21_extensions\\jenkins_pipeline_patch_install.bat ${patchDbFolderName} ${patchConfig.currentTarget}")
 	}
 }
 
 def getCredentialId(def patchConfig) {
-	if(patchConfig.installationTarget.toLowerCase().startsWith("cht")) {
+	if(patchConfig.currentTarget.toLowerCase().startsWith("cht")) {
 		return "svcIt21Install-t"
 	}
 	else {
@@ -75,7 +75,7 @@ def installGUI(patchConfig,artifact,extension) {
 		
 		def extractedGuiPath = ""
 
-		extractedGuiPath = "\\\\service-${patchConfig.installationTarget}.apgsga.ch\\it21_${patchConfig.installationTarget}_gui"
+		extractedGuiPath = "\\\\service-${patchConfig.currentTarget}.apgsga.ch\\it21_${patchConfig.currentTarget}_gui"
 
 		def credentialId = getCredentialId(patchConfig)
 		
@@ -166,7 +166,7 @@ def renameExtractedGuiZip(extractedGuiPath,extractedFolderName) {
 }
 
 def copyGuiOpsResources(patchConfig,extractedGuiPath,extractedFolderName) {
-	dir("C:\\config\\${patchConfig.installationTarget}\\it21-gui") {
+	dir("C:\\config\\${patchConfig.currentTarget}\\it21-gui") {
 		fileOperations ([fileCopyOperation(flattenFiles: true, excludes: '', includes: '*.properties', targetLocation: "${extractedGuiPath}\\${extractedFolderName}\\conf")])
 	}
 }

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -113,7 +113,7 @@ def tagName(patchConfig) {
 def saveTarget(patchConfig, target) {
 	patchConfig.targetBean = target
 	patchConfig.envName = target.envName
-	patchConfig.installationTarget = target.targetName
+	patchConfig.currentTarget = target.targetName
 }
 
 def mavenVersionNumber(patchConfig,revision) {
@@ -123,13 +123,13 @@ def mavenVersionNumber(patchConfig,revision) {
 
 def approveBuild(patchConfig) {
 	timeout(time:5, unit:'DAYS') {
-		userInput = input (id:"Patch${patchConfig.patchNummer}BuildFor${patchConfig.installationTarget}Ok" , message:"Ok for ${patchConfig.installationTarget} Build?" , submitter: 'svcjenkinsclient,che')
+		userInput = input (id:"Patch${patchConfig.patchNummer}BuildFor${patchConfig.currentTarget}Ok" , message:"Ok for ${patchConfig.currentTarget} Build?" , submitter: 'svcjenkinsclient,che')
 	}
 }
 
 def approveInstallation(patchConfig) {
 	timeout(time:5, unit:'DAYS') {
-		userInput = input (id:"Patch${patchConfig.patchNummer}InstallFor${patchConfig.installationTarget}Ok" , message:"Ok for ${patchConfig.installationTarget} Installation?" , submitter: 'svcjenkinsclient,che')
+		userInput = input (id:"Patch${patchConfig.patchNummer}InstallFor${patchConfig.currentTarget}Ok" , message:"Ok for ${patchConfig.currentTarget} Installation?" , submitter: 'svcjenkinsclient,che')
 	}
 }
 
@@ -137,7 +137,7 @@ def approveInstallation(patchConfig) {
 def patchBuildsConcurrent(patchConfig) {
 	node {
 		deleteDir()
-		lock("${patchConfig.serviceName}${patchConfig.installationTarget}Build") {
+		lock("${patchConfig.serviceName}${patchConfig.currentTarget}Build") {
 			coFromBranchCvs(patchConfig, 'it21-ui-bundle', 'microservice')
 			nextRevision(patchConfig)
 			generateVersionProperties(patchConfig)
@@ -154,10 +154,10 @@ def nextRevision(patchConfig) {
 
 def setPatchLastRevision(patchConfig) {
 	def fullRevPrefix = getFullRevisionPrefix(patchConfig)
-	def cmd = "/opt/apg-patch-cli/bin/apsrevcli.sh -lr ${patchConfig.installationTarget}"
+	def cmd = "/opt/apg-patch-cli/bin/apsrevcli.sh -lr ${patchConfig.currentTarget}"
 	def lastTargetRevision = sh ( returnStdout : true, script: cmd).trim()
 	patchConfig.lastRevision = "${fullRevPrefix}${lastTargetRevision}"
-	echo "patchConfig.lastRevision has been set with last Revision for target ${patchConfig.installationTarget}: ${lastTargetRevision}"
+	echo "patchConfig.lastRevision has been set with last Revision for target ${patchConfig.currentTarget}: ${lastTargetRevision}"
 }
 
 def setPatchRevision(patchConfig) {
@@ -169,10 +169,10 @@ def setPatchRevision(patchConfig) {
 
 def saveRevisions(patchConfig) {
 	def fullRevPrefix = getFullRevisionPrefix(patchConfig)
-	def cmd = "/opt/apg-patch-cli/bin/apsrevcli.sh -ar ${patchConfig.installationTarget},${patchConfig.revision},${fullRevPrefix}"
+	def cmd = "/opt/apg-patch-cli/bin/apsrevcli.sh -ar ${patchConfig.currentTarget},${patchConfig.revision},${fullRevPrefix}"
 	def result = sh returnStatus: true, script: "${cmd}"
-	assert result == 0 : println("Error while adding revision ${patchConfig.revision} to target ${patchConfig.installationTarget}")
-	echo "New Revision has been added for ${patchConfig.installationTarget}: ${fullRevPrefix}"
+	assert result == 0 : println("Error while adding revision ${patchConfig.revision} to target ${patchConfig.currentTarget}")
+	echo "New Revision has been added for ${patchConfig.currentTarget}: ${fullRevPrefix}"
 }
 
 def getFullRevisionPrefix(def patchConfig) {


### PR DESCRIPTION
The problem: 

The field installationTarget was used in "conflicting" ways
As Installation Target for OnDemandPipeline from the UI 
Internally as single reference from PatchConfig for the currentTarget being processed. 

With the redo, which saves the PatchConfig State before and after a Stage, this could lead to fact , that the installationTarget is overwritten from the Prod Pipeline.

Solution -> The single Reference in PatchConfig for the currentTarget being processed is renamed to currentTarget.