### PR TITLE
JAVA8MIG-480

### DIFF
--- a/src/main/jenkins/server/patchProdPipeline.groovy
+++ b/src/main/jenkins/server/patchProdPipeline.groovy
@@ -34,8 +34,10 @@ patchfunctions.redoToState(patchConfig)
 // Artefacts are tagged = ready to be buildt and deployed with start of Patch Pipeline
 def target = targetSystemsMap.get('Entwicklung')
 patchfunctions.stage(target,"Installationsbereit",patchConfig,"Notification", patchfunctions.&notify)
+def phases = targetSystemsMap.keySet()
+phases.removeElement('Entwicklung')
 
-['Informatiktest', 'Produktion'].each { envName ->
+phases.each { envName ->
 	target = targetSystemsMap.get(envName)
 	assert target != null
 	patchfunctions.saveTarget(patchConfig,target)

--- a/src/test/groovy/testPhases.groovy
+++ b/src/test/groovy/testPhases.groovy
@@ -1,0 +1,21 @@
+import groovy.json.JsonSlurper
+
+def targetSystemFile = new File('src/test/resources/TargetSystemMappings.json')
+assert targetSystemFile.exists()
+def jsonSystemTargets = new JsonSlurper().parseText(targetSystemFile.text)
+def targetSystemMap = [:]
+jsonSystemTargets.targetSystems.each( { target ->
+	targetSystemMap.put(target.name, [envName:target.name,targetName:target.target])
+})
+println targetSystemMap
+def target = targetSystemMap.get('Entwicklung')
+assert target != null
+def phases = targetSystemMap.keySet()
+phases.removeElement('Entwicklung')
+target = phases.contains('Entwicklung')
+assert !target
+phases.each { envName ->
+	target = targetSystemMap.get(envName)
+	assert target != null
+	println target
+}

--- a/src/test/resources/TargetSystemMappings.json
+++ b/src/test/resources/TargetSystemMappings.json
@@ -1,0 +1,61 @@
+{
+    "targetSystems": [
+        {
+            "name": "Entwicklung",
+            "target": "CHEI212",
+            "stages": [
+                {
+                    "name": "startPipelineAndTag",
+                    "toState": "Installationsbereit",
+                    "code": 2,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.EntwicklungInstallationsbereitAction"
+                },
+                {
+                    "name": "cancel",
+                    "toState": "",
+                    "code": 0,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+                }
+            ]
+        },
+        {
+            "name": "Informatiktest",
+            "target": "CHEI212",
+            "stages": [
+                {
+                    "name": "BuildFor",
+                    "toState": "Installationsbereit",
+                    "code": 15,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+                },
+                {
+                    "name": "InstallFor",
+                    "toState": "",
+                    "code": 20,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+                }
+            ]
+        },
+        {
+            "name": "Produktion",
+            "target": "CHEI211",
+            "stages": [
+                {
+                    "name": "BuildFor",
+                    "toState": "Installationsbereit",
+                    "code": 65,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+                },
+                {
+                    "name": "InstallFor",
+                    "toState": "",
+                    "code": 80,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+                }
+            ]
+        }
+    ],
+    "otherTargetInstances": [
+        "CHEI212"
+    ]
+}


### PR DESCRIPTION
Very small change to patchProdPipeline.groovy. Basically retrieving keySet of the targetSystemMap, removing 'Entwicklung'  and iterating over the list instead of the hardcoded List of values. 

See file compore. 

This means no additional field and / or  format change  of /etc/opt/apg-patch-common/TargetSystemMappings.json is necessary. 

If ok , as soon as merge, additional phases can be added.
