### PR TITLE
Extend TargetSystemMappings with Node Labels For Target

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ repositories {
 		mavenLocal()
 		maven { 
 		  credentials {
-            	username "$repoUser"
-            	password System.env.REPO_RO_PASSWD
+            	username mavenRepoUser
+            	password mavenRepoPwd
         	}
 			url "${mavenRepoBaseUrl}/repo" 
 		}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,0 @@
-mavenRepoBaseUrl=https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga
-org.gradle.caching=false
-repoUser=dev

--- a/src/test/groovy/testPhases.groovy
+++ b/src/test/groovy/testPhases.groovy
@@ -5,7 +5,8 @@ assert targetSystemFile.exists()
 def jsonSystemTargets = new JsonSlurper().parseText(targetSystemFile.text)
 def targetSystemMap = [:]
 jsonSystemTargets.targetSystems.each( { target ->
-	targetSystemMap.put(target.name, [envName:target.name,targetName:target.target])
+	
+	targetSystemMap.put(target.name, [envName:target.name,targetName:target.target, nodes:target.nodes])
 })
 println targetSystemMap
 def target = targetSystemMap.get('Entwicklung')
@@ -18,4 +19,15 @@ phases.each { envName ->
 	target = targetSystemMap.get(envName)
 	assert target != null
 	println target
+	println "Label for service jadas: " + nodeLabelFor('jadas', target.nodes)
+}
+
+def nodeLabelFor(serviceName, nodes) {
+	def found = nodes.find { it.serviceName.equals(serviceName)}
+	if (found != null) {
+		found.label
+	} else {
+		found
+	}
+	
 }

--- a/src/test/resources/TargetSystemMappings.json
+++ b/src/test/resources/TargetSystemMappings.json
@@ -1,61 +1,73 @@
 {
-    "targetSystems": [
-        {
-            "name": "Entwicklung",
-            "target": "CHEI212",
-            "stages": [
-                {
-                    "name": "startPipelineAndTag",
-                    "toState": "Installationsbereit",
-                    "code": 2,
-                    "implcls": "com.apgsga.microservice.patch.server.impl.EntwicklungInstallationsbereitAction"
-                },
-                {
-                    "name": "cancel",
-                    "toState": "",
-                    "code": 0,
-                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
-                }
-            ]
-        },
-        {
-            "name": "Informatiktest",
-            "target": "CHEI212",
-            "stages": [
-                {
-                    "name": "BuildFor",
-                    "toState": "Installationsbereit",
-                    "code": 15,
-                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
-                },
-                {
-                    "name": "InstallFor",
-                    "toState": "",
-                    "code": 20,
-                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
-                }
-            ]
-        },
-        {
-            "name": "Produktion",
-            "target": "CHEI211",
-            "stages": [
-                {
-                    "name": "BuildFor",
-                    "toState": "Installationsbereit",
-                    "code": 65,
-                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
-                },
-                {
-                    "name": "InstallFor",
-                    "toState": "",
-                    "code": 80,
-                    "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
-                }
-            ]
-        }
-    ],
-    "otherTargetInstances": [
-        "CHEI212"
-    ]
+	"targetSystems": [
+		{
+			"name": "Entwicklung",
+			"target": "CHEI212",
+			"nodes": [
+				{
+					"label": "jadas-t",
+					"serviceName": "jadas"
+				}
+			],
+			"stages": [
+				{
+					"name": "startPipelineAndTag",
+					"toState": "Installationsbereit",
+					"code": 2,
+					"implcls": "com.apgsga.microservice.patch.server.impl.EntwicklungInstallationsbereitAction"
+				},
+				{
+					"name": "cancel",
+					"toState": "",
+					"code": 0,
+					"implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+				}
+			]
+		},
+		{
+			"name": "Informatiktest",
+			"target": "CHEI212",
+			"nodes": [
+				{
+					"label": "jadas-t",
+					"serviceName": "jadas"
+				}
+			],
+			"stages": [
+				{
+					"name": "BuildFor",
+					"toState": "Installationsbereit",
+					"code": 15,
+					"implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+				},
+				{
+					"name": "InstallFor",
+					"toState": "",
+					"code": 20,
+					"implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+				}
+			]
+		},
+		{
+			"name": "Produktion",
+			"target": "CHEI211",
+			"stages": [
+				{
+					"name": "BuildFor",
+					"toState": "Installationsbereit",
+					"code": 65,
+					"implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+				},
+				{
+					"name": "InstallFor",
+					"toState": "",
+					"code": 80,
+					"implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+				}
+			]
+		}
+	],
+	"otherTargetInstances": [
+		"CHEI212"
+	]
 }

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -13,6 +13,16 @@ def benchmark() {
 	benchmarkCallback
 }
 
+def nodeLabelFor(serviceName, nodes) {
+	def found = nodes.find { it.serviceName.equals(serviceName)}
+	if (found != null) {
+		found.label
+	} else {
+		found
+	}
+	
+}
+
 def readPatchFile(patchFilePath) {
 	def patchFile = new File(patchFilePath)
 	def patchConfig = new JsonSlurperClassic().parseText(patchFile.text)
@@ -100,7 +110,7 @@ def loadTargetsMap() {
 	def jsonSystemTargets = new JsonSlurper().parseText(targetSystemFile.text)
 	def targetSystemMap = [:]
 	jsonSystemTargets.targetSystems.each( { target ->
-		targetSystemMap.put(target.name, [envName:target.name,targetName:target.target])
+		targetSystemMap.put(target.name, [envName:target.name,targetName:target.target, nodes:target.nodes])
 	})
 	println targetSystemMap
 	targetSystemMap


### PR DESCRIPTION
Suggested changes to support node Labels:

1. TargetSystemMappings.json an additional attribute with a list of serviceName and 
`...
			"nodes": [
				{
					"label": "jadas-t",
					"serviceName": "jadas"
				}
			],
	...
		`

2.  provide a groovy function to retrieve a nodeLabel for a given serviceName
`def nodeLabelFor(serviceName, nodes) `
in /jenkins-patch-scripts/vars/patchfunctions.groovy


I updated TargetSystemMappings.json on jenkins.apgsga.ch accordingly. 
The additional json seems backward compatible