### PR TITLE
Getting node label where top install Jadas Service

### DIFF
--- a/vars/patchDeployment.groovy
+++ b/vars/patchDeployment.groovy
@@ -12,6 +12,8 @@ def installDeploymentArtifacts(patchConfig) {
 		}, 'ui-server-deployment': {
 			if(patchConfig.installJadasAndGui) {
 				// TODO JHE : get the node on which to run the yum command from TargetSystemMapping file. For dev purpose, at the moment, everything will be started from the master
+				//			  Also for dev purpose, at the moment we echo the node information on which the YUM should have ran.
+				echo "Installation of jadas Service should have ran on : ${patchConfig.jadasInstallationNodeLabel}"
 				node {
 					echo "Installation of apg-jadas-service-${patchConfig.currentTarget} starting ..."
 					def yumCmd = "sudo yum clean all && sudo yum -y install apg-jadas-service-${patchConfig.currentTarget}"

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -48,9 +48,14 @@ def savePatchConfigState(patchConfig) {
 	}
 }
 
+def jadasInstallationNode(target) {
+	return target.nodes.label
+}
+
 def stage(target,toState,patchConfig,task, Closure callBack) {
 	echo "target: ${target}, toState: ${toState}, task: ${task} "
 	patchConfig.targetToState = mapToState(target,toState)
+	patchConfig.jadasInstallationNodeLabel = jadasInstallationNodeLabel(target)
 	echo "patchConfig.targetToState: ${patchConfig.targetToState}"
 	echo "patchConfig.redoToState: ${patchConfig.redoToState}"
 	def skip = patchConfig.redo &&


### PR DESCRIPTION
I'll merge it immediately, it serves only as documentation/information purpose. The aim is to retrieve the "node label" where jadas will have to be installed, and assign this value to the patchConfig. For now, until JAVA8MIG-577 will be done, we're only echoing the information.