### PR TITLE
JAVA8MIG-735 OnDemand Pipeline überschreibt persistenten Redo Status

### DIFF
--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -56,6 +56,8 @@ def jadasInstallationNodeLabel(target) {
 
 def stage(target,toState,patchConfig,task, Closure callBack) {
 	echo "target: ${target}, toState: ${toState}, task: ${task} "
+	def targetSystemsMap = patchfunctions.loadTargetsMap()
+	def targetName= targetSystemsMap.get(target.envName)
 	patchConfig.targetToState = mapToState(target,toState)
 	patchConfig.jadasInstallationNodeLabel = jadasInstallationNodeLabel(target)
 	echo "patchConfig.targetToState: ${patchConfig.targetToState}"
@@ -72,15 +74,18 @@ def stage(target,toState,patchConfig,task, Closure callBack) {
 		if (!skip) {
 			echo "Not skipping"
 			// Save before Stage 
-			savePatchConfigState(patchConfig)
+			if (targetName != null) {
+				savePatchConfigState(patchConfig)
+			}
 			if (!nop) {
 				callBack(patchConfig)
 			}
 			if (patchConfig.redo && patchConfig.redoToState.toString().equals(patchConfig.targetToState.toString()) && task.equals("Notification")) {
 				patchConfig.redo = false
 			}
-			// Save after Stage
-			savePatchConfigState(patchConfig)
+			if (targetName != null) {
+				savePatchConfigState(patchConfig)
+			}
 		} else {
 			"Echo skipping"
 		}

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -56,7 +56,7 @@ def jadasInstallationNodeLabel(target) {
 
 def stage(target,toState,patchConfig,task, Closure callBack) {
 	echo "target: ${target}, toState: ${toState}, task: ${task} "
-	def targetSystemsMap = patchfunctions.loadTargetsMap()
+	def targetSystemsMap = loadTargetsMap()
 	def targetName= targetSystemsMap.get(target.envName)
 	patchConfig.targetToState = mapToState(target,toState)
 	patchConfig.jadasInstallationNodeLabel = jadasInstallationNodeLabel(target)


### PR DESCRIPTION
Important decision: the stage(....) wrapper stays also for onDemand Pipeline, although it doesn't provide much value, except the uniform declarative invocation style of our stages.

In the stage(...)  wrapper, we check if the "logical" Targetname , like "Entwicklung" , "Informatiktest" etc is a existing name in Targetsystemmappings. If not like with "OnDemand" the saving of the state of patchConfig is skipped.