### PR TITLE
Patch 6166 enthält nur in GUI-Middle-Tier die richtige Version des Lieferartefaktes, nicht aber im GUI-Client

### DIFF
--- a/src/main/jenkins/server/patchOnDemandPipeline.groovy
+++ b/src/main/jenkins/server/patchOnDemandPipeline.groovy
@@ -19,7 +19,9 @@ patchfunctions.initPatchConfig(patchConfig,params)
 def defaultNodes = [[label:env.DEFAULT_JADAS_ONDEMAND_NODE,serviceName:"jadas"]]
 def target = [envName:"OnDemand",targetName:patchConfig.installationTarget,nodes:defaultNodes]
 patchConfig.currentTarget = patchConfig.installationTarget
-patchfunctions.stage(target,"Installationsbereit",patchConfig,"Build", patchfunctions.&patchBuildsConcurrent)
-patchfunctions.stage(target,"Installationsbereit",patchConfig,"Assembly", patchfunctions.&assembleDeploymentArtefacts)
+lock("${patchConfig.serviceName}${patchConfig.currentTarget}BuildAndAssebly") {
+	patchfunctions.stage(target,"Installationsbereit",patchConfig,"Build", patchfunctions.&patchBuildsConcurrent)
+	patchfunctions.stage(target,"Installationsbereit",patchConfig,"Assembly", patchfunctions.&assembleDeploymentArtefacts)
+}
 patchfunctions.stage(target,"Installation",patchConfig,"InstallOldStyle", patchDeployment.&installOldStyle)
 patchfunctions.stage(target,"Installation",patchConfig,"Install", patchDeployment.&installDeploymentArtifacts)

--- a/src/main/jenkins/server/patchProdPipeline.groovy
+++ b/src/main/jenkins/server/patchProdPipeline.groovy
@@ -44,9 +44,12 @@ phases.each { envName ->
 
 	// Approve to make Patch "Installationsbereit" for target
 	patchfunctions.stage(target,"Installationsbereit",patchConfig,"Approve", patchfunctions.&approveBuild)
-	patchfunctions.stage(target,"Installationsbereit",patchConfig,"Build", patchfunctions.&patchBuildsConcurrent)
-	patchfunctions.stage(target,"Installationsbereit",patchConfig,"Assembly", patchfunctions.&assembleDeploymentArtefacts)
+	lock("${patchConfig.serviceName}${patchConfig.currentTarget}BuildAndAssebly") {
+		patchfunctions.stage(target,"Installationsbereit",patchConfig,"Build", patchfunctions.&patchBuildsConcurrent)
+		patchfunctions.stage(target,"Installationsbereit",patchConfig,"Assembly", patchfunctions.&assembleDeploymentArtefacts)
+	}
 	patchfunctions.stage(target,"Installationsbereit",patchConfig,"Notification",  patchfunctions.&notify)
+	
 	
 	// Approve to to install Patch
 	

--- a/src/main/jenkins/server/patchbuilder.groovy
+++ b/src/main/jenkins/server/patchbuilder.groovy
@@ -13,7 +13,7 @@ pipelineJob (jobName) {
 			sandbox(false)
 		}
 	}
-	logRotator(5,10,5,-1)
+	logRotator(3653,10,3653,-1) // ten years legal retention period
 	description("Patch Pipeline for : ${patchName}")
 	parameters {
 		stringParam('PARAMETER', "", "Pfad zum Patch*.json File")
@@ -35,7 +35,7 @@ pipelineJob (downLoadJobName) {
 			sandbox(false)
 		}
 	}
-	logRotator(5,10,5,-1)
+	logRotator(3653,10,3653,-1) // ten years legal retention period
 	description("OnDemand Patch Pipeline for : ${patchName}")
 	parameters {
 		stringParam('PARAMETER', "", "String mit dem die PatchConfig Parameter als JSON transportiert werden")

--- a/src/main/jenkins/server/patchbuilder.groovy
+++ b/src/main/jenkins/server/patchbuilder.groovy
@@ -13,7 +13,7 @@ pipelineJob (jobName) {
 			sandbox(false)
 		}
 	}
-	logRotator(3653,10,3653,-1) // ten years legal retention period
+	logRotator(3653,10,3653,-1) // ten years legal retention period 
 	description("Patch Pipeline for : ${patchName}")
 	parameters {
 		stringParam('PARAMETER', "", "Pfad zum Patch*.json File")

--- a/vars/patchDeployment.groovy
+++ b/vars/patchDeployment.groovy
@@ -131,7 +131,7 @@ def downloadGuiZipToBeInstalled(artifactoryServer,zip) {
 	def downloadSpec = """{
               "files": [
                     {
-                      "pattern": "releases/*${zip}",
+                      "pattern": "${env.RELEASES_PATCH_REPO}*${zip}",
 					   "target": "download/"
 					   }
 			 ]

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -162,13 +162,11 @@ def approveInstallation(patchConfig) {
 def patchBuildsConcurrent(patchConfig) {
 	node {
 		deleteDir()
-		lock("${patchConfig.serviceName}${patchConfig.currentTarget}Build") {
-			coFromBranchCvs(patchConfig, 'it21-ui-bundle', 'microservice')
-			nextRevision(patchConfig)
-			generateVersionProperties(patchConfig)
-			buildAndReleaseModulesConcurrent(patchConfig)
-			saveRevisions(patchConfig)
-		}
+		coFromBranchCvs(patchConfig, 'it21-ui-bundle', 'microservice')
+		nextRevision(patchConfig)
+		generateVersionProperties(patchConfig)
+		buildAndReleaseModulesConcurrent(patchConfig)
+		saveRevisions(patchConfig)
 	}
 }
 


### PR DESCRIPTION
Der Lock pro Service und Target umfasst nun nicht nur den Build =, sondern auch die Assembly Stage, so werden der Build und Assembly verschiedener Patches in der Reihenfolge serialisiert, wie Sie freigegeben werden.
Bis anhin wurden nur die Builds so serialisiert. 