### PR TITLE
java8mig-730 / Performance Optimising of Multi-Patch Installation

### DIFF
--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -135,6 +135,14 @@ def tagName(patchConfig) {
 		
 }
 
+def tagNameForModule(patchConfig,moduleName) {
+	patchConfig.mavenArtifactsToBuild.each({ma ->
+		if(ma.name.equals(moduleName)) {
+			return ma.patchTag
+		}
+	})
+}
+
 def saveTarget(patchConfig, target) {
 	patchConfig.targetBean = target
 	patchConfig.envName = target.envName
@@ -224,7 +232,13 @@ def buildAndReleaseModulesConcurrent(patchConfig) {
 def buildAndReleaseModulesConcurrent(patchConfig,module) {
 	return {
 		node {
-			def tag = tagName(patchConfig)
+			def tag
+			if(patchConfig.patchNummer.contains("aggregate")) {
+				tag = tagNameForModule(patchConfig,module)	
+			}
+			else {
+				tag = tagName(patchConfig)
+			}
 			coFromTagCvsConcurrent(patchConfig,tag,module.name)
 			coIt21BundleFromBranchCvs(patchConfig) 
 			buildAndReleaseModule(patchConfig,module)

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -366,7 +366,6 @@ def updateBom(patchConfig,module) {
 
 def assembleDeploymentArtefacts(patchConfig) {
 	node {
-		// JHE: parallelized first 2 and last 2
 		parallel 'checkOutAndAssembleDbModules': {
 			coDbModules(patchConfig)
 			dbAssemble(patchConfig)

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -366,10 +366,15 @@ def updateBom(patchConfig,module) {
 
 def assembleDeploymentArtefacts(patchConfig) {
 	node {
-		coDbModules(patchConfig)
-		dbAssemble(patchConfig)
-		coFromBranchCvs(patchConfig, 'it21-ui-bundle', 'microservice')
-		assemble(patchConfig)
+		// JHE: parallelized first 2 and last 2
+		parallel 'checkOutAndAssembleDbModules': {
+			coDbModules(patchConfig)
+			dbAssemble(patchConfig)
+		},
+		'checkoutAndAssembleMavenArtifacts': {
+			coFromBranchCvs(patchConfig, 'it21-ui-bundle', 'microservice')
+			assemble(patchConfig)
+		}
 	}
 }
 

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -135,7 +135,15 @@ def tagName(patchConfig) {
 		
 }
 
-def tagNameForModule(patchConfig,moduleName) {
+def tagNameForDbModule(patchConfig,vcsDboName) {
+	patchConfig.dbObjects.each({dbo -> 
+		if(vcsDboName.contains(dbo.moduleName)) {
+			return dbo.patchTag
+		}
+	})
+}
+
+def tagNameForMavenModule(patchConfig,moduleName) {
 	patchConfig.mavenArtifactsToBuild.each({ma ->
 		if(ma.name.equals(moduleName)) {
 			return ma.patchTag
@@ -234,7 +242,7 @@ def buildAndReleaseModulesConcurrent(patchConfig,module) {
 		node {
 			def tag
 			if(patchConfig.patchNummer.contains("aggregate")) {
-				tag = tagNameForModule(patchConfig,module)	
+				tag = tagNameForMavenModule(patchConfig,module)	
 			}
 			else {
 				tag = tagName(patchConfig)
@@ -269,7 +277,8 @@ def buildAndReleaseModule(patchConfig,module) {
 
 }
 
-
+// JHE: Deprecated function? Can't find where it eventually would be called from
+@Deprecated
 def checkoutModules(patchConfig) {
 	def tag = tagName(patchConfig)
 	patchConfig.mavenArtifactsToBuild.each {
@@ -483,6 +492,9 @@ def coDbModules(patchConfig) {
 	def tag = tagName(patchConfig)
 	dir(patchDbFolderName) {
 		dbObjects.each{ dbo ->
+			if(patchConfig.patchNummer.contains("aggregate")) {
+				tag = tagNameForDbModule(patchConfig,dbo)
+			}
 			coFromTagcvs(patchConfig,tag, dbo)
 		}
 	}


### PR DESCRIPTION
This pull request goes together with Piper https://github.com/apgsga-it/piper/pull/65 . What's missing is:

- To be checked with Ueli which "Old style script" has to be called for this scenario.
- Merging onClone and reinstallPatchAfterClone pipelines into one single pipeline.
- Eventually calling the different steps via stage wrapper

But ... probably already enough to get first feebacks. What has changed is basically:

- We eventually get the patchTag from DB objects and Artifacts.
- DB and Artifacts assemble run in parallel (always, not only for the clone scenario, mmhh, probably still need to be verified if really always OK)
- New call to apscli in order to start the patch aggregation.
