### PR TITLE
java8mig-736 / Refactor Installation Node Selection

### DIFF
--- a/src/main/jenkins/server/clone/onClonePipeline.groovy
+++ b/src/main/jenkins/server/clone/onClonePipeline.groovy
@@ -97,7 +97,7 @@ private def reinstallPatch(def patch, def target) {
 		def targetBean = [envName:target,targetName:patchConfig.currentTarget,nodes:defaultNodes]
 		patchfunctions.saveTarget(patchConfig,targetBean)
 		patchfunctions.mavenLocalRepo(patchConfig)
-		patchConfig.jadasInstallationNodeLabel = patchfunctions.jadasInstallationNodeLabel(targetBean)
+		patchConfig.jadasInstallationNodeLabel = patchfunctions.serviceInstallationNodeLabel(targetBean,"jadas")
 		echo "patchConfig.jadasInstallationNodeLabel set with ${patchConfig.jadasInstallationNodeLabel}"
 		println patchConfig.mavenLocalRepo
 			

--- a/vars/patchDeployment.groovy
+++ b/vars/patchDeployment.groovy
@@ -11,8 +11,9 @@ def installDeploymentArtifacts(patchConfig) {
 			}
 		}, 'ui-server-deployment': {
 			if(patchConfig.installJadasAndGui) {
-				echo "Installation of jadas Service will be done on Node : ${patchConfig.jadasInstallationNodeLabel}"
-				node (patchConfig.jadasInstallationNodeLabel){
+				def installationNodeLabel = patchfunctions.serviceInstallationNodeLabel(patchConfig.targetBean,"jadas")
+				echo "Installation of jadas Service will be done on Node : ${installationNodeLabel}"
+				node (installationNodeLabel){
 					echo "Installation of apg-jadas-service-${patchConfig.currentTarget} starting ..."
 					def yumCmd = "sudo yum clean all && sudo yum -y install apg-jadas-service-${patchConfig.currentTarget}"
 					// JHE: For debug purpose (whoami)

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -1,6 +1,9 @@
+import org.codehaus.groovy.util.StringUtil
+
 import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
 import groovy.json.JsonSlurperClassic
+import groovyjarjarantlr.StringUtils
 import hudson.model.*
 
 def benchmark() {
@@ -48,10 +51,15 @@ def savePatchConfigState(patchConfig) {
 	}
 }
 
-def jadasInstallationNodeLabel(target) {
-	// JHE : at the moment we only have one node pro target, and all dedicated to jadas...
-	// TODO JHE: support fetching service name, and return node accordingly.
-	return target.nodes[0].label
+def serviceInstallationNodeLabel(target,serviceName) {
+	def label = ""
+	target.nodes.each{node -> 
+		if(node.equalsIgnoreCase(serviceName)) {
+			label = node.label
+		}
+	}
+	assert !label?.trim() : "No label found for ${serviceName}"
+	return label
 }
 
 def stage(target,toState,patchConfig,task, Closure callBack) {
@@ -59,7 +67,7 @@ def stage(target,toState,patchConfig,task, Closure callBack) {
 	def targetSystemsMap = loadTargetsMap()
 	def targetName= targetSystemsMap.get(target.envName)
 	patchConfig.targetToState = mapToState(target,toState)
-	patchConfig.jadasInstallationNodeLabel = jadasInstallationNodeLabel(target)
+	patchConfig.jadasInstallationNodeLabel = serviceInstallationNodeLabel(target,"jadas")
 	echo "patchConfig.targetToState: ${patchConfig.targetToState}"
 	echo "patchConfig.redoToState: ${patchConfig.redoToState}"
 	def skip = patchConfig.redo &&

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -67,7 +67,6 @@ def stage(target,toState,patchConfig,task, Closure callBack) {
 	def targetSystemsMap = loadTargetsMap()
 	def targetName= targetSystemsMap.get(target.envName)
 	patchConfig.targetToState = mapToState(target,toState)
-	patchConfig.jadasInstallationNodeLabel = serviceInstallationNodeLabel(target,"jadas")
 	echo "patchConfig.targetToState: ${patchConfig.targetToState}"
 	echo "patchConfig.redoToState: ${patchConfig.redoToState}"
 	def skip = patchConfig.redo &&


### PR DESCRIPTION
The node where to install Jadas Middletier is fetched dynamically based on information coming from targetBean.
The node is now retrieved only when we need it -> at deployment time.
This pull request is ready for feedback, but I would wait until CM-176 will be in production before merging it. If we merge it right now, it might not be easy to determine what will have to me backport on PROD for CM-176 (CM-176 should go in production on 16.04.2019).
Also if we wait before merging, it will be easier to test this one and CM-176 without having undesired side-effects.