### PR TITLE
jhe-cm-176 / distinguished patchToBeReinstall file names

### DIFF
--- a/src/main/jenkins/server/clone/onClonePipeline.groovy
+++ b/src/main/jenkins/server/clone/onClonePipeline.groovy
@@ -143,5 +143,5 @@ private def getPatchListFile(def target) {
 	def cmd = "/opt/apg-patch-cli/bin/apsdbcli.sh -lpac ${status}"
 	def result = sh (returnStdout: true, script: cmd).trim()
 	assert result : println ("Error while getting list of patch to be re-installed on ${target}")
-	return new File("/var/opt/apg-patch-cli/patchToBeReinstalled.json")
+	return new File("/var/opt/apg-patch-cli/patchToBeReinstalled${status}.json")
 }


### PR DESCRIPTION
JSON file with list of patch to be reinstalled needs to have distinguished name for each status (informatiktest, anwendertest, ...)