### PR TITLE
cm-184 / Jenkins Pipeline onClonemaster.light verliert Parameter Defaults

### DIFF
--- a/src/main/jenkins/server/clone/onClonePipeline.groovy
+++ b/src/main/jenkins/server/clone/onClonePipeline.groovy
@@ -2,23 +2,6 @@ package clone
 import groovy.json.JsonSlurper
 import groovy.json.JsonSlurperClassic
 
-/*
-properties([
-	parameters([
-		stringParam(
-			defaultValue: "",
-			description: 'Parameter',
-			name: 'source'
-			),
-		stringParam(
-			defaultValue: "",
-			description: 'Parameter',
-			name: 'target'
-		)
-	])
-])
-*/
-
 def source = env.source
 def target = env.target
 

--- a/src/main/jenkins/server/clone/onClonePipeline.groovy
+++ b/src/main/jenkins/server/clone/onClonePipeline.groovy
@@ -2,23 +2,25 @@ package clone
 import groovy.json.JsonSlurper
 import groovy.json.JsonSlurperClassic
 
+/*
 properties([
 	parameters([
 		stringParam(
-			//defaultValue: "",
+			defaultValue: "",
 			description: 'Parameter',
 			name: 'source'
 			),
 		stringParam(
-			//defaultValue: "",
+			defaultValue: "",
 			description: 'Parameter',
 			name: 'target'
 		)
 	])
 ])
+*/
 
-def source = params.source
-def target = params.target
+def source = env.source
+def target = env.target
 
 println "Parameter ... source = ${source} , target = ${target}"
 

--- a/src/main/jenkins/server/clone/onClonePipeline.groovy
+++ b/src/main/jenkins/server/clone/onClonePipeline.groovy
@@ -5,12 +5,12 @@ import groovy.json.JsonSlurperClassic
 properties([
 	parameters([
 		stringParam(
-			defaultValue: "",
+			//defaultValue: "",
 			description: 'Parameter',
 			name: 'source'
 			),
 		stringParam(
-			defaultValue: "",
+			//defaultValue: "",
 			description: 'Parameter',
 			name: 'target'
 		)


### PR DESCRIPTION
It seems to come from the following bug: https://issues.jenkins-ci.org/browse/JENKINS-43758

None of the suggested workaround in the ticket works for us, or at least their description is not 100% clear.

However, from what I tested, reading the Job parameter from the "env" variable instead of the "params" seem to do it.

This is a very minor correction, I could do some successful tests on jenkins-t. If it has any undesired side-effect, one can very quickly revert it. 