### PR TITLE
1.1.x cm 216

### DIFF
--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -492,7 +492,7 @@ def coDbModules(patchConfig) {
 	** work-around for not yet existing packaging of db scripts, see ticket CM-216
 	*/
 	fileOperations ([
-		folderCreateOperation(folderPath: "oracle")
+		folderCreateOperation(folderPath: "${patchDbFolderName}/oracle")
 	])
 
 	def cvsRoot = patchConfig.cvsroot

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -488,16 +488,22 @@ def coDbModules(patchConfig) {
 	fileOperations ([
 		folderCreateOperation(folderPath: "${patchDbFolderName}")
 	])
+	/*
+	** work-around for not yet existing packaging of db scripts, see ticket CM-216
+	*/
+	fileOperations ([
+		folderCreateOperation(folderPath: "oracle")
+	])
 
 	def cvsRoot = patchConfig.cvsroot
 	
 	def patchNumber = patchConfig.patchNummer
 	def dbPatchTag = patchConfig.patchTag
 	
-	echo "Patch \"${patchNumber}\" being checked out to \"${patchDbFolderName}\""
+	echo "Patch \"${patchNumber}\" being checked out to \"${patchDbFolderName}/oracle\""
 	patchConfig.dbObjects.collect{it.moduleName}.unique().each { dbModule ->
 		echo "- module \"${dbModule}\" tag \"${dbPatchTag}\" being checked out"
-		dir(patchDbFolderName) {
+		dir("${patchDbFolderName}/oracle") {
 			sh "cvs -d${cvsRoot} co -r${dbPatchTag} ${dbModule}"
 		}
 	}

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -504,7 +504,7 @@ def coDbModules(patchConfig) {
 	patchConfig.dbObjects.collect{it.moduleName}.unique().each { dbModule ->
 		echo "- module \"${dbModule}\" tag \"${dbPatchTag}\" being checked out"
 		dir("${patchDbFolderName}/oracle") {
-			def moduleDirectory = (dbModule.replace("com.affichage.","")).replace(".sql","")
+			def moduleDirectory = dbModule.replace(".","_")
 			sh "cvs -d${cvsRoot} co -r${dbPatchTag} -d${moduleDirectory} ${dbModule}"
 		}
 	}

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -504,7 +504,8 @@ def coDbModules(patchConfig) {
 	patchConfig.dbObjects.collect{it.moduleName}.unique().each { dbModule ->
 		echo "- module \"${dbModule}\" tag \"${dbPatchTag}\" being checked out"
 		dir("${patchDbFolderName}/oracle") {
-			sh "cvs -d${cvsRoot} co -r${dbPatchTag} ${dbModule}"
+			def moduleDirectory = (dbModule.replace("com.affichage.","")).replace(".sql","")
+			sh "cvs -d${cvsRoot} co -r${dbPatchTag} -d${moduleDirectory} ${dbModule}"
 		}
 	}
 	echo "Patch \"${patchNumber}\" checked out"


### PR DESCRIPTION
temporary solution to re-enable original installation sequence of scripts for different it21 schema accounts until a "real" packaging is introduced for db objects, see ticket cm-216