### PR TITLE
CM-225 / Patch Produktion-Installation Reihenfolge falsch?

### DIFF
--- a/src/main/jenkins/server/clone/onClonePipeline.groovy
+++ b/src/main/jenkins/server/clone/onClonePipeline.groovy
@@ -91,7 +91,6 @@ private def reinstallPatch(def patch, def target) {
 		stage("Re-installing patch ${patch} on ${patchConfig.currentTarget}") {
 			patchfunctions.stage(targetBean,"Installationsbereit",patchConfig,"Build", patchfunctions.&patchBuildsConcurrent)
 			patchfunctions.stage(targetBean,"Installationsbereit",patchConfig,"Assembly", patchfunctions.&assembleDeploymentArtefacts)
-			patchfunctions.stage(targetBean,"Installation",patchConfig,"InstallOldStyle", patchDeployment.&installOldStyle)
 			patchfunctions.stage(targetBean,"Installation",patchConfig,"Install", patchDeployment.&installDeploymentArtifacts)
 		}
 	}

--- a/src/main/jenkins/server/patchOnDemandPipeline.groovy
+++ b/src/main/jenkins/server/patchOnDemandPipeline.groovy
@@ -22,5 +22,4 @@ patchConfig.currentTarget = patchConfig.installationTarget
 patchConfig.targetBean = target
 patchfunctions.stage(target,"Installationsbereit",patchConfig,"Build", patchfunctions.&patchBuildsConcurrent)
 patchfunctions.stage(target,"Installationsbereit",patchConfig,"Assembly", patchfunctions.&assembleDeploymentArtefacts)
-patchfunctions.stage(target,"Installation",patchConfig,"InstallOldStyle", patchDeployment.&installOldStyle)
 patchfunctions.stage(target,"Installation",patchConfig,"Install", patchDeployment.&installDeploymentArtifacts)

--- a/src/main/jenkins/server/patchProdPipeline.groovy
+++ b/src/main/jenkins/server/patchProdPipeline.groovy
@@ -51,7 +51,6 @@ phases.each { envName ->
 	// Approve to to install Patch
 	
 	patchfunctions.stage(target,"Installation",patchConfig,"Approve", patchfunctions.&approveInstallation)
-	patchfunctions.stage(target,"Installation",patchConfig,"InstallOldStyle", patchDeployment.&installOldStyle)
 	patchfunctions.stage(target,"Installation",patchConfig,"Install", patchDeployment.&installDeploymentArtifacts)
 	patchfunctions.stage(target,"Installation",patchConfig,"Postprocess",  patchfunctions.&installationPostProcess)
 	patchfunctions.stage(target,"Installation",patchConfig,"Notification",  patchfunctions.&notify)

--- a/vars/patchDeployment.groovy
+++ b/vars/patchDeployment.groovy
@@ -6,6 +6,10 @@ def installDeploymentArtifacts(patchConfig) {
 	def targetSystemMappingJson = patchfunctions.getTargetSystemMappingJson()
 	
 	lock("${patchConfig.serviceName}${patchConfig.currentTarget}Install") {
+		// CM-225: old style needs to be part of the "installLock" (It can not run parallel to "db-deployment")
+		echo "${new Date().format('yyyy-MM-dd HH:mm:ss.S')}: Starting installOldStyle"
+		installOldStyle(patchConfig)
+		echo "${new Date().format('yyyy-MM-dd HH:mm:ss.S')}: Done installOldStyle"
 		parallel 'ui-client-deployment': {
 			if(patchConfig.installJadasAndGui && !isLightInstallation(patchConfig.currentTarget,targetSystemMappingJson)) {
 				node {

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -69,7 +69,7 @@ def stage(target,toState,patchConfig,task, Closure callBack) {
 	echo "patchConfig.redoToState: ${patchConfig.redoToState}"
 	def skip = patchConfig.redo &&
 			(!(patchConfig.redoToState.toString().equals(patchConfig.targetToState.toString()) && patchConfig.lastPipelineTask.toString().equals(task.toString())))
-	def nop = !skip && patchConfig.mavenArtifacts.empty && patchConfig.dbObjects.empty && !patchConfig.installJadasAndGui && !["Approve","Notification","InstallOldStyle"].contains(task)
+	def nop = !skip && patchConfig.mavenArtifacts.empty && patchConfig.dbObjects.empty && !patchConfig.installJadasAndGui && !["Approve","Notification"].contains(task)
 	echo "skip = ${skip}"
 	echo "nop  = ${nop}"
 	def stageText = "${target.envName} (${target.targetName}) ${toState} ${task} "  + (skip ? "(Skipped)" : (nop ? "(Nop)" : "") )


### PR DESCRIPTION
InstallOldStyle can lead to wrong installation order when a patch goes into production. The step needs to be part of the "installLock".