### PR TITLE
CM-262 / CVS Merge of Patch-Tag to prod Branch does not overwrite

### DIFF
--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -516,6 +516,8 @@ def mergeDbObjectOnHead(patchConfig, envName) {
 				def tmpFolderDir = "cvsExportTemp_${patchNumber}"
 				sh "mkdir -p ${tmpFolderDir}"
 				sh "cd ${tmpFolderDir} && cvs -d${cvsRoot} export -r ${dbPatchTag} ${dbModule}"
+				// JHE: Needs to be removed, but need to know in which folder exactly we are a this point
+				sh "pwd"
 				sh "find * -type f -exec cp -f -p {} ../{} \\;"
 				sh "cd .. && rm -Rf ${tmpFolderDir}"
 				sh "cvs -d${cvsRoot} commit -m 'merge ${dbPatchTag} to branch'"

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -516,10 +516,8 @@ def mergeDbObjectOnHead(patchConfig, envName) {
 				def tmpFolderDir = "cvsExportTemp_${patchNumber}"
 				sh "mkdir -p ${tmpFolderDir}"
 				sh "cd ${tmpFolderDir} && cvs -d${cvsRoot} export -r ${dbPatchTag} ${dbModule}"
-				// JHE: Needs to be removed, but need to know in which folder exactly we are a this point
-				sh "pwd"
 				sh "cd ${tmpFolderDir} && find * -type f -exec cp -f -p {} ../{} \\;"
-				sh "cd .. && rm -Rf ${tmpFolderDir}"
+				sh "rm -Rf ${tmpFolderDir}"
 				sh "cvs -d${cvsRoot} commit -m 'merge ${dbPatchTag} to branch'"
 			}
 			log("... ${dbModule} commited", "mergeDbObjectOnHead")

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -515,11 +515,9 @@ def mergeDbObjectOnHead(patchConfig, envName) {
 				log("... ${dbModule} tag \"${dbPatchTag}\" had merge conflicts for branch \"${dbProdBranch}\" -> forcing contents of tag \"${dbPatchTag}\"","mergeDbObjectOnHead")
 				def tmpFolderDir = "cvsExportTemp_${patchNumber}"
 				sh "mkdir -p ${tmpFolderDir}"
-				sh "cd ${tmpFolderDir}"
-				sh "cvs -d${cvsRoot} export -r ${dbPatchTag} ${dbModule}"
+				sh "cd ${tmpFolderDir} && cvs -d${cvsRoot} export -r ${dbPatchTag} ${dbModule}"
 				sh "find * -type f -exec cp -f -p {} ../../{} \\;"
-				sh "cd .."
-				sh "rm -Rf ${tmpFolderDir}"
+				sh "cd .. && rm -Rf ${tmpFolderDir}"
 				sh "cvs -d${cvsRoot} commit -m 'merge ${dbPatchTag} to branch'"
 			}
 			log("... ${dbModule} commited", "mergeDbObjectOnHead")

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -516,7 +516,7 @@ def mergeDbObjectOnHead(patchConfig, envName) {
 				def tmpFolderDir = "cvsExportTemp_${patchNumber}"
 				sh "mkdir -p ${tmpFolderDir}"
 				sh "cd ${tmpFolderDir} && cvs -d${cvsRoot} export -r ${dbPatchTag} ${dbModule}"
-				sh "find * -type f -exec cp -f -p {} ../../{} \\;"
+				sh "find * -type f -exec cp -f -p {} ../{} \\;"
 				sh "cd .. && rm -Rf ${tmpFolderDir}"
 				sh "cvs -d${cvsRoot} commit -m 'merge ${dbPatchTag} to branch'"
 			}

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -512,7 +512,7 @@ def mergeDbObjectOnHead(patchConfig, envName) {
 			try {
 				sh "cvs -d${cvsRoot} commit -m 'merge ${dbPatchTag} to branch ${dbProdBranch}' ${dbModule}"
 			} catch (Exception mergeEx) {
-				log("... ${dbModule} tag \"${dbPatchTag}\" had merge conflicts for branch \"${dbProdBranch}\" - forcing contents of tag \"${dbPatchTag}\"","mergeDbObjectOnHead")
+				log("... ${dbModule} tag \"${dbPatchTag}\" had merge conflicts for branch \"${dbProdBranch}\" -> forcing contents of tag \"${dbPatchTag}\"","mergeDbObjectOnHead")
 				def tmpFolderDir = "cvsExportTemp_${patchNumber}"
 				sh "mkdir -p ${tmpFolderDir}"
 				sh "cd ${tmpFolderDir}"

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -509,7 +509,19 @@ def mergeDbObjectOnHead(patchConfig, envName) {
 			log("... ${dbModule} tagged ${dbTagBeforeMerge}", "mergeDbObjectOnHead")
 			sh "cvs -d${cvsRoot} up -j ${dbPatchTag} ${dbModule}"
 			log("... ${dbModule} tag \"${dbPatchTag}\" merged to branch \"${dbProdBranch}\"", "mergeDbObjectOnHead")
-			sh "cvs -d${cvsRoot} commit -m 'merge ${dbPatchTag} to branch ${dbProdBranch}' ${dbModule}"
+			try {
+				sh "cvs -d${cvsRoot} commit -m 'merge ${dbPatchTag} to branch ${dbProdBranch}' ${dbModule}"
+			} catch (Exception mergeEx) {
+				log("... ${dbModule} tag \"${dbPatchTag}\" had merge conflicts for branch \"${dbProdBranch}\" - forcing contents of tag \"${dbPatchTag}\"","mergeDbObjectOnHead")
+				def tmpFolderDir = "cvsExportTemp_${patchNumber}"
+				sh "mkdir -p ${tmpFolderDir}"
+				sh "cd ${tmpFolderDir}"
+				sh "cvs -d${cvsRoot} export -r ${dbPatchTag} ${dbModule}"
+				sh "find * -type f -exec cp -f -p {} ../../{} \\;"
+				sh "cd .."
+				sh "rm -Rf ${tmpFolderDir}"
+				sh "cvs -d${cvsRoot} commit -m 'merge ${dbPatchTag} to branch'"
+			}
 			log("... ${dbModule} commited", "mergeDbObjectOnHead")
 			sh "cvs -d${cvsRoot} tag -F ${dbTagAfterMerge} ${dbModule}"
 			log("... ${dbModule} tagged ${dbTagAfterMerge}", "mergeDbObjectOnHead")

--- a/vars/patchfunctions.groovy
+++ b/vars/patchfunctions.groovy
@@ -518,7 +518,7 @@ def mergeDbObjectOnHead(patchConfig, envName) {
 				sh "cd ${tmpFolderDir} && cvs -d${cvsRoot} export -r ${dbPatchTag} ${dbModule}"
 				// JHE: Needs to be removed, but need to know in which folder exactly we are a this point
 				sh "pwd"
-				sh "find * -type f -exec cp -f -p {} ../{} \\;"
+				sh "cd ${tmpFolderDir} && find * -type f -exec cp -f -p {} ../{} \\;"
 				sh "cd .. && rm -Rf ${tmpFolderDir}"
 				sh "cvs -d${cvsRoot} commit -m 'merge ${dbPatchTag} to branch'"
 			}


### PR DESCRIPTION
When encountering a db-objects merge conflict at the end of patch, we want to overwrite the content of the prod branch with the content coming from patch tag.